### PR TITLE
update list of test targets

### DIFF
--- a/tests/test_sniffers.py
+++ b/tests/test_sniffers.py
@@ -43,6 +43,7 @@ matched_vpns = [('vpn.{}.edu'.format(d), s) for d, s in (
     ('174.127.47.193', sn.check_point),  # no DNS?
     ('nomad.sandiego.edu', sn.aruba_via),
     ('viavpn.luther.edu', sn.aruba_via),
+    ('vpn.wdc.softlayer.com', sn.array_networks),
     ]
 
 unmatched_vpns = ['vpn.{}.edu'.format(d) for d in (
@@ -51,7 +52,6 @@ unmatched_vpns = ['vpn.{}.edu'.format(d) for d in (
     'valpo',
     'uu',
     'drew',  # FIXME: false-negative SonicWall
-    'softlayer',  # FIXME: false-negative Array Networks
     )]
 
 class test_known_servers:


### PR DESCRIPTION
Fixes #4.

Part of the VPNs listed on https://vpn.softlayer.com/ →https://www.ibm.com/cloud/vpn-access are online and detected as Array Networks VPNs:
```
$ what-vpn vpn.dal05.softlayer.com
vpn.dal05.softlayer.com: timeout (tried 1/12 sniffers)
$ 
$ what-vpn vpn.dal06.softlayer.com
vpn.dal06.softlayer.com: Array Networks
$ 
$ what-vpn vpn.dal09.softlayer.com
vpn.dal09.softlayer.com: Array Networks
$ 
$ what-vpn vpn.dal10.softlayer.com
vpn.dal10.softlayer.com: Array Networks
$ 
$ what-vpn vpn.hou02.softlayer.com
vpn.hou02.softlayer.com: timeout (tried 1/12 sniffers)
$ 
$ what-vpn vpn.mex01.softlayer.com
vpn.mex01.softlayer.com: Array Networks
$ 
$ what-vpn vpn.mon01.softlayer.com
vpn.mon01.softlayer.com: SSL errors (tried 1/12 sniffers)
$ OPENSSL_CONF=~/openssl.conf what-vpn vpn.mon01.softlayer.com
vpn.mon01.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.sjc03.softlayer.com
vpn.sjc03.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.sao01.softlayer.com
vpn.sao01.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.tor01.softlayer.com
vpn.tor01.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.wdc01.softlayer.com
vpn.wdc01.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.wdc04.softlayer.com
vpn.wdc04.softlayer.com: Array Networks (10%)
$ 
$ what-vpn vpn.wdc.softlayer.com
vpn.wdc.softlayer.com: Array Networks
$ 
```
But then they are not part of an `.edu` domain and cannot be tested with this code:
https://github.com/dlenski/what-vpn/blob/d76f7aa83df4e5b4376efc3d31c499262585b17f/tests/test_sniffers.py#L48-L55