### PR TITLE
update list of test targets

### DIFF
--- a/tests/test_sniffers.py
+++ b/tests/test_sniffers.py
@@ -18,7 +18,6 @@ matched_vpns = [('vpn.{}.edu'.format(d), s) for d, s in (
     ('fau', sn.juniper_pulse),
     ('simmons', sn.check_point),
     ('nl', sn.anyconnect),
-    ('ycp', sn.fortinet),
     ('uakron', sn.fortinet),              # bad cert
     ('louisville', sn.global_protect),    # portal
     ('usmma', sn.global_protect),         # portal+gateway, ccert


### PR DESCRIPTION
While I can ping `vpn.ycp.edu`, I cannot connect to port 443.

Fixes #10.