### PR TITLE
Partially fix SonicWall detection from Europe

### DIFF
--- a/what_vpn/sniffers.py
+++ b/what_vpn/sniffers.py
@@ -320,9 +320,15 @@ def sonicwall_nx(sess, server):
     sess.cookies.set(domain=server, name='EXTRAWEB_REFERER', value='/preauthMI/microinterrogator.js')
     with closing(sess.get('https://{}/sslvpnclient?launchplatform=mac&neProto=3&supportipv6=yes'.format(server), stream=True,
                           headers={"X-SSLVPN-PROTOCOL": "2.0", "X-SSLVPN-SERVICE": "NETEXTENDER", "X-NE-PROTOCOL": "2.0"})) as r:
-        if 'EXTRAWEB_STATE' in sess.cookies and 400 <= r.status_code < 500:
+        if 400 <= r.status_code < 500:
             server = r.headers.get('server')
-            return Hit(name='SonixWall NX', confidence=0.8, version=server)
+            if 'EXTRAWEB_STATE' in sess.cookies:
+                confidence = 0.8
+            else:
+                confidence = 0.3
+                if 'SonicWall' in r.text:
+                    confidence += 0.2
+            return Hit(name='SonixWall NX', confidence=confidence, version=server)
 
 
 def aruba_via(sess, server):


### PR DESCRIPTION
Fixes (only partially) #14.

Before this patch:
````
$ what-vpn -v -K vpn.drew.edu vpn.valpo.edu

Sniffing vpn.drew.edu ...
  Is it AnyConnect/OpenConnect? connection error
  Is it Juniper/Pulse? no match
  Is it Juniper Secure Connect? no match
  Is it PAN GlobalProtect? no match
  Is it Barracuda? no match
  Is it Check Point? timeout
  Is it SSTP? connection error
  Is it OpenVPN? no match
  Is it Fortinet? no match
  Is it Array Networks? no match
  Is it F5 BigIP? no match
  Is it SonicWall NX (formerly Dell)? no match
  Is it Aruba VIA? no match
  Is it H3C TLS VPN? no match
  Is it Huawei SSL VPN? no match
  => timeout

Sniffing vpn.valpo.edu ...
  Is it AnyConnect/OpenConnect? no match
  Is it Juniper/Pulse? no match
  Is it Juniper Secure Connect? no match
  Is it PAN GlobalProtect? no match
  Is it Barracuda? no match
  Is it Check Point? no match
  Is it SSTP? no match
  Is it OpenVPN? no match
  Is it Fortinet? no match
  Is it Array Networks? no match
  Is it F5 BigIP? no match
  Is it SonicWall NX (formerly Dell)? no match
  Is it Aruba VIA? no match
  Is it H3C TLS VPN? no match
  Is it Huawei SSL VPN? no match
  => no match
$ 
```

After this patch:
```
$ what-vpn -v -K vpn.drew.edu vpn.valpo.edu

Sniffing vpn.drew.edu ...
  Is it AnyConnect/OpenConnect? connection error
  Is it Juniper/Pulse? no match
  Is it Juniper Secure Connect? no match
  Is it PAN GlobalProtect? no match
  Is it Barracuda? no match
  Is it Check Point? timeout
  Is it SSTP? connection error
  Is it OpenVPN? no match
  Is it Fortinet? no match
  Is it Array Networks? no match
  Is it F5 BigIP? no match
  Is it SonicWall NX (formerly Dell)? SonixWall NX (SonicWALL, 50%)
  => SonixWall NX (SonicWALL, 50%)

Sniffing vpn.valpo.edu ...
  Is it AnyConnect/OpenConnect? no match
  Is it Juniper/Pulse? no match
  Is it Juniper Secure Connect? no match
  Is it PAN GlobalProtect? no match
  Is it Barracuda? no match
  Is it Check Point? no match
  Is it SSTP? no match
  Is it OpenVPN? no match
  Is it Fortinet? no match
  Is it Array Networks? no match
  Is it F5 BigIP? no match
  Is it SonicWall NX (formerly Dell)? SonixWall NX (SonicWALL SSL-VPN Web Server, 30%)
  => SonixWall NX (SonicWALL SSL-VPN Web Server, 30%)
$ 
```